### PR TITLE
Remove incomplete installation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,3 @@ if(WIN32)
         PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${SFML_SOURCE_DIR}/extlibs/bin/$<IF:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>,x64,x86>/openal32.dll $<TARGET_FILE_DIR:main>
         VERBATIM)
 endif()
-
-install(TARGETS main)


### PR DESCRIPTION
Installing applications with runtime assets like fonts and shared libraries is not trivial. This single install command gives users the impression that they can install their programs but falls short of what many users would need so for now we're better off removing it until we can provide a more robust one-size-fits-all solution for installation.

Closes #6 