### PR TITLE
Build static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(CMakeSFMLProject LANGUAGES CXX)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
 include(FetchContent)
 FetchContent_Declare(SFML


### PR DESCRIPTION
Closes #11

Static libraries are a better default since it's less common to need shared libraries. Users who explicitly want shared libs may still enable it if they wish.

This lets us remove `if (WIN32 AND BUILD_SHARED_LIBS)` if we'd like to simplify the build script. That's a rather sophisticated bit of CMake code and I worry that it makes the build scripts a lot harder to understand. We're better off hardcoding [`CMAKE_RUNTIME_OUTPUT_DIRECTORY`](https://cmake.org/cmake/help/latest/variable/CMAKE_RUNTIME_OUTPUT_DIRECTORY.html) if we want to make sure all executables and DLLs end up in the same directory.