### PR TITLE
Automatically copy OpenAL DLL into same directory as executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,12 @@ add_executable(CMakeSFMLProject src/main.cpp)
 target_link_libraries(CMakeSFMLProject PRIVATE sfml-graphics)
 target_compile_features(CMakeSFMLProject PRIVATE cxx_std_17)
 
+if(WIN32)
+    add_custom_command(
+        TARGET CMakeSFMLProject
+        COMMENT "Copy OpenAL DLL"
+        PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${SFML_SOURCE_DIR}/extlibs/bin/$<IF:$<BOOL:${ARCH_64BITS}>,x64,x86>/openal32.dll $<TARGET_FILE_DIR:CMakeSFMLProject>
+        VERBATIM)
+endif()
+
 install(TARGETS CMakeSFMLProject)


### PR DESCRIPTION
Closes #13 

This should fix a long standing problem where anyone trying to use the Audio module on Windows has to dig into build/_deps/sfml-src to find the correct OpenAL DLL and copy that into whatever directory contained their executable. 

<img width="621" alt="Screenshot 2023-09-07 at 1 16 53 PM" src="https://github.com/SFML/cmake-sfml-project/assets/39244355/edd2f870-7fda-4343-a3a1-f4abb81a6f9f">

I ran a quick test with CI to confirm that file is in fact being copied to the right place. On MinGW it's copied to build/bin and with MSVC it's at build/bin/$\<CONFIG\>.