### PR TITLE
Don't install SFML when installing the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.28)
 project(CMakeSFMLProject LANGUAGES CXX)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -8,7 +8,9 @@ include(FetchContent)
 FetchContent_Declare(SFML
     GIT_REPOSITORY https://github.com/SFML/SFML.git
     GIT_TAG 2.6.x
-    GIT_SHALLOW ON)
+    GIT_SHALLOW ON
+    EXCLUDE_FROM_ALL
+    SYSTEM)
 FetchContent_MakeAvailable(SFML)
 
 add_executable(main src/main.cpp)


### PR DESCRIPTION
Just a case of adding the subdirectory with `EXCLUDE_FROM_ALL`. ~~In cmake 3.28 you can pass this property directly to fetchcontent which is nicer but presume we're a way off using that version~~ As discussed, we are happy to move to 3.28 as part of this

Also had to change the fetch content name to lowercase, which is required for the source/binary dir variables to work correctly and is good practice anyway.

closes #6 

edit: bonus side-effect of users not having to build sfml modules they aren't using