### PR TITLE
Add Nix-shell script

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs.buildPackages; [
+      gcc_multi
+      cmake
+      sfml
+      csfml
+      libGL
+      udev
+      openal
+      libvorbis
+      flac
+      xorg.libX11
+      xorg.libXrandr
+      xorg.libXcursor
+      xorg.libXext
+      xorg.libXxf86vm
+      freetype
+    ];
+}


### PR DESCRIPTION
Add Nix-shell script for Nix / NixOS users

Tested on NixOS unstable. The usual commands to compile with cmake work, except that I had to require the X11 lib in `CMakeLists.txt` by adding
```
find_package(X11 REQUIRED)
```
Feel free to add a line about this in `CMakeLists.txt` too, as it seems required for Linux-based systems (even those running on Wayland-based environments). I did not include anything about this in this branch as it is beyond its scope I think.

As a reminder, to activate the nix-shell (just like you would with a Python `virtualenv`), just do `nix-shell` in the project's root directory. In this shell, you can then build with
```
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build
```
as you would on any other Linux distro.
