### PR TITLE
Remove out of date docs about building static libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,6 @@ The nice folks in the [SFML community](https://github.com/SFML/SFML#community) c
 
 Modify CMake options by adding them as configuration parameters (with a `-D` flag) or by modifying the contents of CMakeCache.txt and rebuilding.
 
-### Use Static Libraries
-
-By default SFML builds shared libraries and this default is inherited by your project.
-CMake's [`BUILD_SHARED_LIBS`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) option lets you pick static or shared libraries for the entire project.
-
 ### Change Compilers
 
 See the variety of [`CMAKE_<LANG>_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) options.


### PR DESCRIPTION
https://github.com/SFML/cmake-sfml-project/blob/814646cab61c34ef222ce76aef1ce658f0d8a3cd/CMakeLists.txt#L5

The template already builds static libraries by default so we don't need a note in the README about this. We could instead change this to `Use Dynamic Libraries` but I don't think that's necessary.