### PR TITLE
Use shallow git clone for SFML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 include(FetchContent)
 FetchContent_Declare(SFML
     GIT_REPOSITORY https://github.com/SFML/SFML.git
-    GIT_TAG 2.6.x)
+    GIT_TAG 2.6.x
+    GIT_SHALLOW ON)
 FetchContent_MakeAvailable(SFML)
 
 add_executable(main src/main.cpp)


### PR DESCRIPTION
Knocks ~130MB off the download size