### PR TITLE
Create and install .app bundles on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,42 @@ add_executable(main src/main.cpp)
 target_link_libraries(main PRIVATE sfml-graphics)
 target_compile_features(main PRIVATE cxx_std_17)
 
+if(APPLE)
+    # On macOS, bundle the executable into an .app bundle
+    set(MACOSX_BUNDLE_BUNDLE_NAME main)
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.example.main") # com.YOURCOMPANY.YOURAPP
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "1.0")
+    set(MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0")
+
+    # Specify the output format as a macOS bundle
+    set_target_properties(main PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_BINARY_DIR}/Info.plist
+        INSTALL_RPATH "@loader_path/../Frameworks" # Set the runtime search path
+    )
+
+    # Fill in the Info.plist file with the project's name and other variables
+    configure_file(${CMAKE_SOURCE_DIR}/Info.plist.in ${CMAKE_BINARY_DIR}/Info.plist @ONLY)
+
+    # After building, copy SFML frameworks into the .app bundle
+    add_custom_command(TARGET main POST_BUILD
+        # Ensure the Frameworks directory exists
+        COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_BUNDLE_DIR:main>/Contents/Frameworks
+        # Copy the necessary SFML frameworks
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_BINARY_DIR}/_deps/sfml-src/extlibs/libs-osx/Frameworks
+            $<TARGET_BUNDLE_DIR:main>/Contents/Frameworks
+        COMMENT "Copying SFML frameworks to the .app bundle"
+        VERBATIM
+    )
+
+    # Add install target (macOS app bundle)
+    install(TARGETS main BUNDLE DESTINATION /Applications)
+else()
+    # Add install target (regular executable)
+    install(TARGETS main RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
 if(WIN32)
     add_custom_command(
         TARGET main

--- a/Info.plist.in
+++ b/Info.plist.in
@@ -2,16 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <!-- Name of the executable file in the bundle. -->
     <key>CFBundleExecutable</key>
     <string>@MACOSX_BUNDLE_BUNDLE_NAME@</string>
+
+    <!-- Unique identifier for the application, typically in reverse DNS format. -->
     <key>CFBundleIdentifier</key>
     <string>@MACOSX_BUNDLE_GUI_IDENTIFIER@</string>
+
+    <!-- Short name of the bundle. This is the name that appears in the Finder and other parts of the macOS user interface. -->
     <key>CFBundleName</key>
     <string>@MACOSX_BUNDLE_BUNDLE_NAME@</string>
+
+    <!-- Version of the bundle. This is a string that represents the build version of the application. -->
     <key>CFBundleVersion</key>
     <string>@MACOSX_BUNDLE_BUNDLE_VERSION@</string>
+
+    <!-- Release version number of the bundle. This is a user-visible version number. -->
     <key>CFBundleShortVersionString</key>
     <string>@MACOSX_BUNDLE_SHORT_VERSION_STRING@</string>
+
+    <!-- Type of bundle. For applications, this is typically APPL. -->
     <key>CFBundlePackageType</key>
     <string>APPL</string>
 </dict>

--- a/Info.plist.in
+++ b/Info.plist.in
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>@MACOSX_BUNDLE_BUNDLE_NAME@</string>
+    <key>CFBundleIdentifier</key>
+    <string>@MACOSX_BUNDLE_GUI_IDENTIFIER@</string>
+    <key>CFBundleName</key>
+    <string>@MACOSX_BUNDLE_BUNDLE_NAME@</string>
+    <key>CFBundleVersion</key>
+    <string>@MACOSX_BUNDLE_BUNDLE_VERSION@</string>
+    <key>CFBundleShortVersionString</key>
+    <string>@MACOSX_BUNDLE_SHORT_VERSION_STRING@</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR implements automatic builds of `.app` bundles for macOS. Each bundle is self-contained and includes all the necessary dependencies.

```sh
[~/dev/cmake-sfml-project/build/bin] $ tree -L4
.
└── main.app
    └── Contents
        ├── Frameworks
        │   ├── FLAC.framework
        │   ├── OpenAL.framework
        │   ├── freetype.framework
        │   ├── ogg.framework
        │   ├── vorbis.framework
        │   ├── vorbisenc.framework
        │   └── vorbisfile.framework
        ├── Info.plist
        └── MacOS
            └── main

12 directories, 2 files
```

## Run

You can run the app in three different ways:

1. **Double-click** the `main.app` bundle in Finder.
2. **Use the `open` command**: `open main.app`.
3. **Run the binary directly**: `./main.app/Contents/MacOS/main`.

The last one is called automatically in VScode during development.

## Install

For end users, the app can be installed with:

```sh
sudo cmake --install .
```

This installs the app to `/Applications` along with the required frameworks, allowing it to run out of the box on my system. However, I haven't tested it on a clean macOS environment, so it's unclear if it will work without development dependencies like `xcode-select --install`.

```sh
[/Applications] $ otool -L main.app/Contents/MacOS/main
main.app/Contents/MacOS/main:
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 3038.1.255)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2566.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 170.0.0)
	@rpath/../Frameworks/freetype.framework/Versions/A/freetype (compatibility version 2.8.0, current version 2.8.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.101.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3038.1.255)
	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1883.0.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```

## Other platforms

For completeness, I also added an install target for GNU/Linux and Windows. On GNU/Linux, the app is installed to `/usr/local/bin` and works as expected. A `.desktop` file for better integration would be a nice enhancement, but that's out of scope for this PR.