### PR TITLE
Specify C++17 requirement explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,5 @@ FetchContent_Declare(SFML
 FetchContent_MakeAvailable(SFML)
 
 add_executable(main src/main.cpp)
+target_compile_features(main PRIVATE cxx_std_17)
 target_link_libraries(main PRIVATE SFML::Graphics)


### PR DESCRIPTION
While I guess it's implicitly set by using SFML, it makes sense to have this option explicitly set on the target executable.