### PR TITLE
Update README.md to the new CMake targets for SFML 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The template starts out very basic, but might receive additional features over t
 3. Clone your new GitHub repo and open the repo in your text editor of choice.
 4. Open [CMakeLists.txt](CMakeLists.txt). Rename the project and the target name of the executable to whatever name you want. Make sure to change all occurrences.
 5. If you want to add or remove any .cpp files, change the source files listed in the `add_executable` call in CMakeLists.txt to match the source files your project requires. If you plan on keeping the default main.cpp file then no changes are required.
-6. If your code uses the Audio or Network modules then add `sfml-audio` or `sfml-network` to the `target_link_libraries` call alongside the existing `sfml-graphics` library that is being linked.
+6. If your code uses the Audio or Network modules then add `SFML::Audio` or `SFML::Network` to the `target_link_libraries` call alongside the existing `SFML::Graphics` library that is being linked.
 7. If you use Linux, install SFML's dependencies using your system package manager. On Ubuntu and other Debian-based distributions you can use the following commands:
    ```
    sudo apt update


### PR DESCRIPTION
In step 6 the user is told how to link SFML libraries with CMake targets. I updated the CMake targets to the new SFML version 3 targets