### PR TITLE
Set VS startup project correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,5 @@ FetchContent_MakeAvailable(SFML)
 add_executable(main src/main.cpp)
 target_compile_features(main PRIVATE cxx_std_17)
 target_link_libraries(main PRIVATE SFML::Graphics)
+
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT main)


### PR DESCRIPTION
Another very common problem people hit - they (reasonably) expect to open the solution and be able to run straight away, but cmake always defaults to the `ALL_BUILD` target unless otherwise specified