### PR TITLE
Treat compilation warnings as errors on all CI platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Configure
-      run: cmake -B build ${{matrix.platform.flags}} ${{matrix.config.flags}}
+      run: cmake -B build -DCMAKE_COMPILE_WARNING_AS_ERROR=ON ${{matrix.platform.flags}} ${{matrix.config.flags}}
 
     - name: Build
       run: cmake --build build --config Release


### PR DESCRIPTION
Resolves #69.