### PR TITLE
Use classic green circle code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,20 +2,20 @@
 
 int main()
 {
-    auto window = sf::RenderWindow(sf::VideoMode({1920u, 1080u}), "CMake SFML Project");
-    window.setFramerateLimit(144);
+	sf::RenderWindow window( sf::VideoMode( { 200, 200 } ), "SFML works!" );
+	sf::CircleShape shape( 100.f );
+	shape.setFillColor( sf::Color::Green );
 
-    while (window.isOpen())
-    {
-        while (const std::optional event = window.pollEvent())
-        {
-            if (event->is<sf::Event::Closed>())
-            {
-                window.close();
-            }
-        }
+	while ( window.isOpen() )
+	{
+		while ( const std::optional event = window.pollEvent() )
+		{
+			if ( event->is<sf::Event::Closed>() )
+				window.close();
+		}
 
-        window.clear();
-        window.display();
-    }
+		window.clear();
+		window.draw( shape );
+		window.display();
+	}
 }


### PR DESCRIPTION
Appreciate the desire to keep the project as minimal as possible, but currently it just displays a blank window, which can easily be misconstrued as not working

This changes it to use the quintessential "green circle" code to align with what all the official tutorials use to demonstrate SFML is working