### PR TITLE
docs: add Fedora 40+ DNF dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ The template starts out very basic, but might receive additional features over t
 4. Open [CMakeLists.txt](CMakeLists.txt). Rename the project and the target name of the executable to whatever name you want. Make sure to change all occurrences.
 5. If you want to add or remove any .cpp files, change the source files listed in the `add_executable` call in CMakeLists.txt to match the source files your project requires. If you plan on keeping the default main.cpp file then no changes are required.
 6. If your code uses the Audio or Network modules then add `SFML::Audio` or `SFML::Network` to the `target_link_libraries` call alongside the existing `SFML::Graphics` library that is being linked.
-7. If you use Linux, install SFML's dependencies using your system package manager. On Ubuntu and other Debian-based distributions you can use the following commands:
+7. If you use Linux, install SFML's dependencies using your system package manager.
+   On Ubuntu and other Debian-based distributions you can use the following commands:
    ```
    sudo apt update
    sudo apt install \
@@ -36,7 +37,23 @@ The template starts out very basic, but might receive additional features over t
        libmbedtls-dev \
        libssh2-1-dev
    ```
-8. Configure and build your project. Most popular IDEs support CMake projects with very little effort on your part.
+   On Fedora 40+ and other systems using the DNF5 package manager, you can use the following commands:
+   ```
+   sudo dnf install \
+    libXrandr-devel \
+    libXcursor-devel \
+    libXi-devel \
+    systemd-devel \
+    freetype-devel \
+    flac-devel \
+    libvorbis-devel \
+    mesa-libGL-devel \
+    mesa-libEGL-devel \
+    harfbuzz-devel \
+    mbedtls-devel \
+    libssh2-devel
+   ```
+9. Configure and build your project. Most popular IDEs support CMake projects with very little effort on your part.
 
    - [VS Code](https://code.visualstudio.com) via the [CMake extension](https://code.visualstudio.com/docs/cpp/cmake-linux)
    - [Visual Studio](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170)
@@ -51,7 +68,7 @@ The template starts out very basic, but might receive additional features over t
    cmake --build build
    ```
 
-9. Enjoy!
+10. Enjoy!
 
 ### Visual Studio
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The template starts out very basic, but might receive additional features over t
     mbedtls-devel \
     libssh2-devel
    ```
-9. Configure and build your project. Most popular IDEs support CMake projects with very little effort on your part.
+8. Configure and build your project. Most popular IDEs support CMake projects with very little effort on your part.
 
    - [VS Code](https://code.visualstudio.com) via the [CMake extension](https://code.visualstudio.com/docs/cpp/cmake-linux)
    - [Visual Studio](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170)
@@ -68,7 +68,7 @@ The template starts out very basic, but might receive additional features over t
    cmake --build build
    ```
 
-10. Enjoy!
+9. Enjoy!
 
 ### Visual Studio
 


### PR DESCRIPTION
Added instructions for installing SFML dependencies on Fedora systems using DNF5.